### PR TITLE
Add FastAPI web UI and shared helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+*.sqlite3
+.DS_Store
+.idea/
+.mypy_cache/
+pytest_cache/
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,101 @@
-# Resume_Chatbot
-An LLM Resume Chatbot that uses RAG to answer all questions about me
+# Resume Chatbot
+
+An end-to-end Retrieval Augmented Generation (RAG) chatbot that can answer questions about your resume. The project ships with a lightweight in-memory retriever, a simple fallback "LLM" for offline experimentation, and optional OpenAI integration for production-grade responses.
+
+## Features
+
+- **Markdown-first ingestion** – drop one or more `.md`/`.txt` files into `data/resume/` and the loader will automatically split them into semantic sections.
+- **Pure Python retriever** – a custom TF-IDF retriever implemented with the standard library (no heavyweight ML dependencies required).
+- **Pluggable LLM backends** – start with the deterministic `SimpleLLM` for local testing or switch to OpenAI with a single flag.
+- **Command line chat** – interact with your resume through an interactive CLI powered by Typer and Rich.
+- **Knowledge graph enrichment** – optionally describe entities and relationships in `knowledge_graph.json` to add structured
+  context to retrieval.
+- **Test coverage** – unit tests that exercise the retriever and the full RAG pipeline.
+
+## Project layout
+
+```
+resume_chatbot/
+├── data_loader.py       # Parses resume files into structured documents
+├── retriever.py         # Lightweight TF-IDF retriever and similarity scoring
+├── llm.py               # Abstractions for language models + Simple/OpenAI backends
+├── chatbot.py           # High-level orchestration of retrieval + generation
+├── cli.py               # Typer-powered CLI entrypoint
+└── __init__.py
+```
+
+Supporting files:
+
+- `data/resume/resume_example.md` – sample resume content to get you started.
+- `data/resume/knowledge_graph.json` – structured relationships that are automatically converted into retrievable text.
+- `pyproject.toml` – dependency metadata (install with `pip install -e .`).
+- `tests/` – unit tests for the retriever and chatbot.
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .[dev]
+   ```
+
+2. **Add your resume data**
+
+- Replace the sample files in `data/resume/` with your own Markdown/Plain-text resume. Headings (e.g. `## Experience`) are used to create focused chunks for retrieval.
+- (Optional) Update `knowledge_graph.json` with important entities, relationships, dates, and technologies. The CLI will load the
+  graph and expose the information as additional context for retrieval.
+
+3. **(Optional) Configure OpenAI**
+
+   Create a `.env` file or export the variables directly in your shell:
+
+   ```bash
+   export OPENAI_API_KEY="sk-..."
+   export OPENAI_MODEL="gpt-4o-mini"  # defaults to gpt-3.5-turbo if unset
+   ```
+
+4. **Chat with your resume (CLI)**
+
+   ```bash
+   python -m resume_chatbot.cli chat \
+       --resume-directory data/resume \
+       --llm simple            # or "openai" if you configured an API key
+   ```
+
+   Type your questions and press <kbd>Enter</kbd>. Use `exit` or `quit` to leave the session. When the OpenAI backend is enabled, the assistant automatically adds the retrieved resume snippets to the prompt.
+
+5. **Launch the web app**
+
+   ```bash
+   uvicorn resume_chatbot.webapp:app --reload
+   ```
+
+   Visit [http://127.0.0.1:8000](http://127.0.0.1:8000) to use the responsive chat UI. The interface displays source snippets
+   alongside each answer so you can verify grounding.
+
+## Running tests
+
+Run the automated test suite any time you change the code or resume content:
+
+```bash
+pytest
+```
+
+## How it works
+
+1. **Document loading** – `data_loader.load_resume_documents` reads Markdown/text files and breaks them into sections with metadata (`title`, `source`).
+2. **Vectorisation & retrieval** – `retriever.ResumeRetriever` tokenises text, computes TF-IDF style weights, and scores similarity using cosine distance.
+3. **Response generation** – `chatbot.ResumeChatbot` fetches the most relevant sections, builds a context string, and forwards it to the configured LLM backend.
+4. **CLI** – `python -m resume_chatbot.cli chat` wires everything together for an interactive experience.
+
+The modular design lets you swap the retriever or LLM while keeping the rest of the pipeline untouched.
+
+## Next steps
+
+- Replace the sample resume with your own data and regenerate the vector store at runtime.
+- Deploy the CLI with a web frontend (e.g. FastAPI + React) or integrate it into Slack/Teams bots.
+- Experiment with other LLM providers by creating a new backend that implements `BaseLLM`.
+
+Happy hacking!

--- a/data/resume/knowledge_graph.json
+++ b/data/resume/knowledge_graph.json
@@ -1,0 +1,139 @@
+{
+  "title": "Yutian Yang Resume Knowledge Graph",
+  "nodes": [
+    {"id": "yutian-yang", "label": "Yutian Yang", "type": "Person"},
+    {"id": "onshape-ptc", "label": "Onshape by PTC (R&D Strategy)", "type": "Organization"},
+    {"id": "pinecone", "label": "Pinecone", "type": "Organization"},
+    {"id": "allschool", "label": "Allschool", "type": "Organization"},
+    {"id": "ucd-economics", "label": "UC Davis Department of Economics", "type": "Organization"},
+    {"id": "ucd-ms", "label": "University of California, Davis — M.S. Statistics", "type": "Education"},
+    {"id": "ucd-bs", "label": "University of California, Davis — B.S. Statistics & Economics", "type": "Education"},
+    {"id": "project-mushroom", "label": "Classification of Mushrooms Project", "type": "Project"},
+    {"id": "skill-programming", "label": "Programming Languages", "type": "Skill"},
+    {"id": "skill-ml", "label": "Machine Learning", "type": "Skill"},
+    {"id": "skill-data-engineering", "label": "Data Engineering", "type": "Skill"},
+    {"id": "skill-bi", "label": "Business Intelligence & Analytics", "type": "Skill"},
+    {"id": "tech-aws-bedrock", "label": "AWS Bedrock", "type": "Technology"},
+    {"id": "tech-claude", "label": "Claude 3.5 Sonnet", "type": "Technology"},
+    {"id": "tech-titan-embeddings", "label": "Titan Embeddings", "type": "Technology"},
+    {"id": "tech-prophet", "label": "Prophet", "type": "Technology"},
+    {"id": "tech-isolation-forest", "label": "Isolation Forest", "type": "Technology"},
+    {"id": "tech-merlion", "label": "Merlion", "type": "Technology"},
+    {"id": "tech-lstm-ae", "label": "LSTM Autoencoder", "type": "Technology"},
+    {"id": "tech-looker", "label": "Looker", "type": "Technology"},
+    {"id": "tech-sql", "label": "SQL", "type": "Technology"},
+    {"id": "tech-sigma", "label": "Sigma", "type": "Technology"},
+    {"id": "tech-bigquery", "label": "BigQuery", "type": "Technology"},
+    {"id": "tech-dbt", "label": "dbt", "type": "Technology"},
+    {"id": "tech-python", "label": "Python", "type": "Technology"},
+    {"id": "tech-random-forest", "label": "Random Forest", "type": "Technology"},
+    {"id": "community-wiml", "label": "Women in Machine Learning Mentorship Program", "type": "Community"},
+    {"id": "community-seattle-ai", "label": "Seattle Applied AI Meetup", "type": "Community"}
+  ],
+  "edges": [
+    {
+      "source": "yutian-yang",
+      "target": "onshape-ptc",
+      "relation": "interned_at",
+      "start": "June 2025",
+      "end": "August 2025",
+      "location": "Boston, MA",
+      "description": "Data Science Intern focused on R&D strategy with API telemetry analytics and AI feedback research.",
+      "highlights": [
+        "Implemented Prophet with Isolation Forest for anomaly detection",
+        "Leveraged AWS Bedrock Titan Embeddings and Claude 3.5 Sonnet to cluster NPS feedback",
+        "Built Looker dashboards and Slack automation for anomaly monitoring"
+      ]
+    },
+    {
+      "source": "yutian-yang",
+      "target": "pinecone",
+      "relation": "interned_at",
+      "start": "June 2024",
+      "end": "August 2024",
+      "location": "New York, NY",
+      "description": "Data Science Intern supporting go-to-market analytics and product intelligence.",
+      "highlights": [
+        "Designed Book of Business and Account 360 dashboards with SQL and Sigma",
+        "Created dim_assistants schema in BigQuery and dbt",
+        "Conducted churn analysis with Random Forest models resulting in 10% churn reduction"
+      ]
+    },
+    {
+      "source": "yutian-yang",
+      "target": "allschool",
+      "relation": "interned_at",
+      "start": "June 2022",
+      "end": "August 2022",
+      "location": "San Mateo, CA",
+      "description": "Data Analyst Intern in Growth & BI with experimentation and dashboard automation initiatives.",
+      "highlights": [
+        "Executed A/B tests and segmentation analyses on traffic and revenue",
+        "Evaluated multi-channel acquisition behaviour using SQL and BI tooling",
+        "Developed Selenium web scraper and Looker Studio dashboard for real-time visibility"
+      ]
+    },
+    {
+      "source": "yutian-yang",
+      "target": "ucd-economics",
+      "relation": "research_assistant_at",
+      "start": "July 2020",
+      "end": "September 2020",
+      "location": "Davis, CA",
+      "description": "Research Assistant analysing procrastination and present-biased behaviour with Professor Anujit Chakraborty.",
+      "highlights": [
+        "Applied bootstrapping to expand the dataset to 20,000 observations",
+        "Used logistic regression and GLMs to study behavioural trends",
+        "Implemented Lasso regularisation to address multicollinearity"
+      ]
+    },
+    {
+      "source": "yutian-yang",
+      "target": "ucd-ms",
+      "relation": "earned_degree",
+      "start": "September 2021",
+      "end": "June 2023",
+      "location": "Davis, CA",
+      "description": "Master of Science in Statistics with advanced coursework in statistical computing, machine learning, and optimisation."
+    },
+    {
+      "source": "yutian-yang",
+      "target": "ucd-bs",
+      "relation": "earned_degree",
+      "start": "September 2017",
+      "end": "June 2021",
+      "location": "Davis, CA",
+      "description": "Bachelor of Science in Statistics and Economics."
+    },
+    {
+      "source": "yutian-yang",
+      "target": "project-mushroom",
+      "relation": "built_project",
+      "description": "Collaborated on mushroom classification models using Random Forest, Kernel SVM, CNNs, and ResNet50 transfer learning.",
+      "highlights": [
+        "Implemented hyperparameter tuning with grid search",
+        "Evaluated deep learning architectures for image classification"
+      ]
+    },
+    {"source": "yutian-yang", "target": "skill-programming", "relation": "skilled_in", "description": "Experienced in SQL, Python, and R."},
+    {"source": "yutian-yang", "target": "skill-ml", "relation": "skilled_in", "description": "Hands-on with Scikit-learn, TensorFlow, Random Forests, SVM, CNN, and time series techniques."},
+    {"source": "yutian-yang", "target": "skill-data-engineering", "relation": "skilled_in", "description": "Builds data pipelines with BigQuery, dbt, AWS, GCP, and ETL design."},
+    {"source": "yutian-yang", "target": "skill-bi", "relation": "skilled_in", "description": "Develops BI assets with Tableau, Power BI, Looker, Sigma, and Google Analytics."},
+    {"source": "yutian-yang", "target": "community-wiml", "relation": "volunteers_with", "description": "Mentor with the WiML Mentorship Program."},
+    {"source": "yutian-yang", "target": "community-seattle-ai", "relation": "organises", "description": "Organizer for the 1,200+ member Seattle Applied AI Meetup."},
+    {"source": "onshape-ptc", "target": "tech-aws-bedrock", "relation": "used_technology", "description": "Leveraged AWS Bedrock services for feedback clustering."},
+    {"source": "onshape-ptc", "target": "tech-claude", "relation": "used_technology", "description": "Applied Claude 3.5 Sonnet for qualitative analysis."},
+    {"source": "onshape-ptc", "target": "tech-titan-embeddings", "relation": "used_technology", "description": "Generated embeddings for clustering feedback."},
+    {"source": "onshape-ptc", "target": "tech-prophet", "relation": "used_technology", "description": "Deployed Prophet-based anomaly detection pipeline."},
+    {"source": "onshape-ptc", "target": "tech-isolation-forest", "relation": "used_technology", "description": "Combined Isolation Forest with Prophet for anomaly scoring."},
+    {"source": "onshape-ptc", "target": "tech-merlion", "relation": "evaluated_technology", "description": "Benchmarked Merlion for anomaly detection."},
+    {"source": "onshape-ptc", "target": "tech-lstm-ae", "relation": "evaluated_technology", "description": "Tested LSTM autoencoder for telemetry anomalies."},
+    {"source": "onshape-ptc", "target": "tech-looker", "relation": "used_technology", "description": "Built Looker dashboards for anomaly visibility."},
+    {"source": "pinecone", "target": "tech-sql", "relation": "used_technology", "description": "Developed dashboards and analyses with SQL."},
+    {"source": "pinecone", "target": "tech-sigma", "relation": "used_technology", "description": "Built executive dashboards in Sigma."},
+    {"source": "pinecone", "target": "tech-bigquery", "relation": "used_technology", "description": "Modeled data in BigQuery."},
+    {"source": "pinecone", "target": "tech-dbt", "relation": "used_technology", "description": "Implemented dbt transformations for analytics."},
+    {"source": "pinecone", "target": "tech-python", "relation": "used_technology", "description": "Ran churn modelling workflows in Python."},
+    {"source": "pinecone", "target": "tech-random-forest", "relation": "used_technology", "description": "Built Random Forest models for churn detection."}
+  ]
+}

--- a/data/resume/resume_example.md
+++ b/data/resume/resume_example.md
@@ -1,0 +1,56 @@
+# Yutian Yang
+
+## Summary
+Data scientist and analytics engineer with experience turning experimentation, telemetry, and feedback data into product insights. Skilled at building end-to-end machine learning pipelines, automating analytics workflows, and communicating findings with stakeholders across product, growth, and research teams.
+
+## Contact
+- Phone: +1-501-368-9640
+- Email: charlieyang990314@gmail.com
+- Portfolio: https://charlieyang1557.github.io/aboutme/
+- LinkedIn: https://linkedin.com/in/yutianyang
+
+## Education
+### University of California, Davis — M.S. Statistics (Sep 2021 – Jun 2023)
+- College of Letters and Science
+- Graduate coursework: Advanced Statistical Computing, Algorithm Design & Analysis, Econometrics, Optimization of Big Data Analytics, Statistical Machine Learning I, Statistical Methods of Machine Learning, Time Series Analysis, Probability Theory.
+
+### University of California, Davis — B.S. Statistics & Economics (Sep 2017 – Jun 2021)
+- College of Letters and Science
+
+## Skills
+- Programming: SQL, Python, R
+- Machine Learning: Scikit-learn, TensorFlow, Random Forests, SVM, CNN, Time Series modeling
+- Data Engineering: BigQuery, dbt, AWS, GCP, ETL development, schema design
+- Business Intelligence: Tableau, Power BI, Looker, Sigma, Google Analytics
+
+## Professional Experience
+### Data Science Intern — Onshape by PTC (R&D Strategy) (Jun 2025 – Aug 2025, Boston, MA)
+- Built and evaluated unsupervised anomaly detection models (Prophet with Isolation Forest, Merlion, LSTM autoencoder) for API telemetry monitoring; productionised the Prophet pipeline for strong performance and maintainability.
+- Applied AWS Bedrock's Titan Embeddings and Claude 3.5 Sonnet to cluster, label, and analyse sentiment across NPS feedback, surfacing actionable themes from unstructured text.
+- Conducted keyword coverage analysis on AI Advisor queries to identify reference URL gaps and inform content roadmap updates.
+- Developed Looker dashboards and Slack automations that summarised anomaly alerts and AI insights, reducing manual monitoring overhead.
+
+### Data Science Intern — Pinecone (Jun 2024 – Aug 2024, New York, NY)
+- Designed the Book of Business and Account 360 dashboards with SQL and Sigma, boosting sales operations productivity by 15% and documenting processes to shorten onboarding by 30%.
+- Developed the `dim_assistants` schema in BigQuery and dbt, then launched the Pinecone Assistant dashboard to monitor product metrics and enable cross-team insight sharing.
+- Executed churn analysis in Python with Random Forest models, identifying five leading indicators and launching alerting that contributed to a 10% churn reduction while informing new data collection for higher fidelity signals.
+
+### Data Analyst Intern — Allschool (Growth & BI) (Jun 2022 – Aug 2022, San Mateo, CA)
+- Ran A/B tests and segmentation analyses on user traffic and revenue across regions and platforms, informing impression targeting and engagement strategies via Google Analytics.
+- Evaluated multi-channel acquisition behaviour with SQL and BI tooling, trimming project budget by 15% while increasing daily active users.
+- Built a Selenium-powered web scraper that accelerated class selection by 50% and delivered a Looker Studio dashboard tracking active users, traffic, and revenue.
+
+### Research Assistant — UC Davis Department of Economics (Jul 2020 – Sep 2020, Davis, CA)
+- Modelled procrastination and present-biased behaviour with generalised linear models and logistic regression under Professor Anujit Chakraborty.
+- Applied bootstrapping to expand the analytical sample to roughly 20,000 observations, boosting statistical reliability.
+- Used Lasso regularisation to address multicollinearity among predictors and strengthen behavioural predictions, translating findings into actionable insights for product teams focused on user retention.
+
+## Projects
+### Classification of Mushrooms: Edible or Poisonous (Python)
+- Collaborated on machine learning and deep learning workflows—including Random Forest, Kernel SVM, and CNN architectures—to classify mushroom images.
+- Applied grid search for hyperparameter optimisation and transfer learning with a pre-trained ResNet50 model to improve inference accuracy.
+- Evaluated model performance and recommended future experiments exploring alternative pre-trained networks and architecture adjustments.
+
+## Volunteering & Community
+- Mentor, Women in Machine Learning (WiML) Mentorship Program.
+- Organizer, Seattle Applied AI Meetup (1,200+ members).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "resume-chatbot"
+version = "0.1.0"
+description = "A retrieval-augmented generation (RAG) chatbot for answering questions about a resume."
+readme = "README.md"
+authors = [{name = "Your Name", email = "you@example.com"}]
+requires-python = ">=3.10"
+dependencies = [
+    "typer>=0.9",
+    "rich>=13",
+    "python-dotenv>=1.0",
+    "openai>=1.14",
+    "fastapi>=0.110",
+    "uvicorn>=0.29",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+]
+
+[project.urls]
+Homepage = "https://example.com"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["resume_chatbot*"]

--- a/resume_chatbot/__init__.py
+++ b/resume_chatbot/__init__.py
@@ -1,0 +1,24 @@
+"""Resume Chatbot package."""
+
+from .chatbot import DEFAULT_SYSTEM_PROMPT, ResumeChatbot, ChatResult
+from .data_loader import Document, load_resume_documents
+from .corpus import load_resume_corpus
+from .knowledge_graph import load_knowledge_graph_documents
+from .retriever import ResumeRetriever, RetrievedDocument
+from .llm import BaseLLM, SimpleLLM, OpenAIChatLLM, create_llm
+
+__all__ = [
+    "DEFAULT_SYSTEM_PROMPT",
+    "ResumeChatbot",
+    "ChatResult",
+    "Document",
+    "load_resume_documents",
+    "load_resume_corpus",
+    "load_knowledge_graph_documents",
+    "ResumeRetriever",
+    "RetrievedDocument",
+    "BaseLLM",
+    "SimpleLLM",
+    "OpenAIChatLLM",
+    "create_llm",
+]

--- a/resume_chatbot/chatbot.py
+++ b/resume_chatbot/chatbot.py
@@ -1,0 +1,81 @@
+"""High-level orchestration of retrieval and generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+from .llm import BaseLLM
+from .retriever import RetrievedDocument, ResumeRetriever
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a helpful assistant that answers questions about a single candidate's resume. "
+    "Use only the provided resume context. If the answer is not in the context, say you don't know."
+)
+
+
+@dataclass(frozen=True)
+class ChatResult:
+    """Result of a chat interaction."""
+
+    answer: str
+    documents: List[RetrievedDocument]
+
+
+class ResumeChatbot:
+    """Combine a retriever and an LLM to answer resume questions."""
+
+    def __init__(
+        self,
+        retriever: ResumeRetriever,
+        llm: BaseLLM,
+        *,
+        system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+        history_limit: int = 5,
+    ) -> None:
+        self._retriever = retriever
+        self._llm = llm
+        self._system_prompt = system_prompt
+        self._history_limit = max(0, history_limit)
+        self._history: list[tuple[str, str]] = []
+
+    @staticmethod
+    def _format_context(retrieved_documents: Sequence[RetrievedDocument]) -> str:
+        sections: list[str] = []
+        for item in retrieved_documents:
+            metadata = item.document.metadata
+            title = metadata.get("title")
+            source = metadata.get("source", "resume")
+            header = f"[{source}]"
+            if title:
+                header = f"[{source} :: {title}]"
+            sections.append(f"{header}\n{item.document.content}")
+        return "\n\n".join(sections)
+
+    def ask(self, question: str, *, top_k: int = 3) -> ChatResult:
+        """Answer ``question`` using the resume corpus."""
+
+        retrieved = self._retriever.retrieve(question, top_k=top_k)
+        context = self._format_context(retrieved)
+        answer = self._llm.generate(
+            question,
+            context,
+            system_prompt=self._system_prompt,
+            chat_history=tuple(self._history),
+        )
+        if self._history_limit:
+            self._history.append((question, answer))
+            if len(self._history) > self._history_limit:
+                self._history = self._history[-self._history_limit :]
+        return ChatResult(answer=answer, documents=list(retrieved))
+
+    def reset_history(self) -> None:
+        """Clear the stored chat history."""
+
+        self._history.clear()
+
+    @property
+    def history(self) -> Tuple[tuple[str, str], ...]:
+        """Return the stored chat history as ``(question, answer)`` pairs."""
+
+        return tuple(self._history)

--- a/resume_chatbot/cli.py
+++ b/resume_chatbot/cli.py
@@ -1,0 +1,109 @@
+"""Command line interface for the resume chatbot."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from .chatbot import DEFAULT_SYSTEM_PROMPT, ResumeChatbot
+from .corpus import load_resume_corpus
+from .llm import create_llm
+from .retriever import ResumeRetriever
+
+app = typer.Typer(add_completion=False)
+console = Console()
+
+
+def _load_system_prompt(path: Optional[Path]) -> str:
+    if path is None:
+        return DEFAULT_SYSTEM_PROMPT
+    text = path.read_text(encoding="utf-8").strip()
+    return text or DEFAULT_SYSTEM_PROMPT
+
+
+@app.command()
+def chat(
+    resume_directory: Path = typer.Option(
+        Path("data/resume"),
+        exists=True,
+        readable=True,
+        dir_okay=True,
+        file_okay=False,
+        help="Directory containing Markdown or text resume files.",
+    ),
+    llm: str = typer.Option(
+        "simple",
+        help="LLM backend to use ('simple' for offline mode or 'openai' for API-backed responses).",
+    ),
+    top_k: int = typer.Option(3, min=1, max=10, help="Number of resume sections to retrieve."),
+    system_prompt_path: Optional[Path] = typer.Option(
+        None,
+        help="Optional path to a custom system prompt file.",
+    ),
+    history_limit: int = typer.Option(5, min=0, help="How many previous turns to retain in the prompt."),
+    show_sources: bool = typer.Option(
+        True,
+        help="Display the resume sections that were retrieved for each answer.",
+    ),
+) -> None:
+    """Start an interactive chat session."""
+
+    documents = load_resume_corpus(resume_directory)
+    if not documents:
+        console.print(
+            f"[red]No resume documents found in {resume_directory}. Add Markdown or text files and try again.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    retriever = ResumeRetriever(documents)
+    try:
+        llm_client = create_llm(llm)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    system_prompt = _load_system_prompt(system_prompt_path)
+
+    chatbot = ResumeChatbot(
+        retriever=retriever,
+        llm=llm_client,
+        system_prompt=system_prompt,
+        history_limit=history_limit,
+    )
+
+    console.print(Panel("Resume Chatbot\nType 'exit' or 'quit' to leave.", title="RAG"))
+
+    while True:
+        try:
+            console.print("[bold cyan]You:[/bold cyan] ", end="")
+            question = input().strip()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[bold yellow]Session ended by user.[/bold yellow]")
+            break
+
+        if not question:
+            continue
+        if question.lower() in {"exit", "quit"}:
+            console.print("[green]Goodbye![/green]")
+            break
+
+        result = chatbot.ask(question, top_k=top_k)
+        console.print(Panel(result.answer, title="Assistant", style="green"))
+        if show_sources and result.documents:
+            console.print("[bold magenta]Sources:[/bold magenta]")
+            for item in result.documents:
+                metadata = item.document.metadata
+                source = metadata.get("source", "resume")
+                title = metadata.get("title")
+                score = f"{item.score:.3f}"
+                if title:
+                    console.print(f"  - {source} :: {title} (score={score})")
+                else:
+                    console.print(f"  - {source} (score={score})")
+            console.print()
+
+
+if __name__ == "__main__":
+    app()

--- a/resume_chatbot/corpus.py
+++ b/resume_chatbot/corpus.py
@@ -1,0 +1,20 @@
+"""Helpers for assembling the resume corpus used by retrieval."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .data_loader import Document, load_resume_documents
+from .knowledge_graph import load_knowledge_graph_documents
+
+
+def load_resume_corpus(directory: Path) -> List[Document]:
+    """Load resume sections plus optional knowledge graph context from ``directory``."""
+
+    documents = load_resume_documents(directory)
+    documents.extend(load_knowledge_graph_documents(directory))
+    return documents
+
+
+__all__ = ["load_resume_corpus"]

--- a/resume_chatbot/data_loader.py
+++ b/resume_chatbot/data_loader.py
@@ -1,0 +1,87 @@
+"""Utilities for loading resume documents from disk."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class Document:
+    """Simple container for resume content and metadata."""
+
+    content: str
+    metadata: dict
+
+
+def _iter_text_files(directory: Path) -> Iterable[Path]:
+    """Yield text-like files from ``directory`` sorted by name."""
+
+    for path in sorted(directory.rglob("*")):
+        if path.is_file() and path.suffix.lower() in {".md", ".txt"}:
+            yield path
+
+
+def _split_markdown_sections(text: str) -> Sequence[tuple[str, str]]:
+    """Split a Markdown document into ``(title, body)`` sections."""
+
+    sections: list[tuple[str, list[str]]] = []
+    current_title = "Overview"
+    current_lines: list[str] = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if line.startswith("#"):
+            if current_lines:
+                sections.append((current_title, current_lines))
+                current_lines = []
+            current_title = line.lstrip("# ").strip() or current_title
+        else:
+            current_lines.append(line)
+    if current_lines:
+        sections.append((current_title, current_lines))
+
+    normalised_sections: list[tuple[str, str]] = []
+    for title, lines in sections:
+        body = "\n".join(line for line in lines).strip()
+        if body:
+            normalised_sections.append((title, body))
+    if not normalised_sections and text.strip():
+        normalised_sections.append(("Overview", text.strip()))
+    return normalised_sections
+
+
+def load_resume_documents(directory: Path) -> List[Document]:
+    """Load and split resume documents from ``directory``.
+
+    Parameters
+    ----------
+    directory:
+        Directory containing Markdown or plain-text resume files.
+
+    Returns
+    -------
+    list[Document]
+        Parsed documents, each capturing a logical resume section.
+    """
+
+    directory = directory.expanduser().resolve()
+    if not directory.exists():
+        return []
+
+    documents: list[Document] = []
+    for path in _iter_text_files(directory):
+        text = path.read_text(encoding="utf-8")
+        for idx, (title, body) in enumerate(_split_markdown_sections(text), start=1):
+            documents.append(
+                Document(
+                    content=body,
+                    metadata={
+                        "source": str(path.relative_to(directory)),
+                        "title": title,
+                        "chunk": idx,
+                    },
+                )
+            )
+    return documents

--- a/resume_chatbot/knowledge_graph.py
+++ b/resume_chatbot/knowledge_graph.py
@@ -1,0 +1,129 @@
+"""Utilities for loading and formatting resume knowledge graphs."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .data_loader import Document
+
+
+def _ensure_sentence(text: str) -> str:
+    text = text.strip()
+    if not text:
+        return ""
+    if text[-1] in ".!?":
+        return text
+    return f"{text}."
+
+
+def _format_timeframe(start: Optional[str], end: Optional[str]) -> Optional[str]:
+    if start and end:
+        return f"{start} to {end}"
+    if start:
+        return f"starting {start}"
+    if end:
+        return f"until {end}"
+    return None
+
+
+def _format_fact(
+    subject: str,
+    relation: str,
+    target: str,
+    *,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    location: Optional[str] = None,
+    description: Optional[str] = None,
+    highlights: Optional[Iterable[str]] = None,
+) -> str:
+    relation_text = relation.replace("_", " ").strip() or "related to"
+    sentences: List[str] = [f"{subject} {relation_text} {target}."]
+
+    timeframe = _format_timeframe(start, end)
+    if timeframe:
+        sentences.append(f"The timeframe was {timeframe}.")
+    if location:
+        sentences.append(f"This took place in {location}.")
+    if description:
+        sentences.append(_ensure_sentence(description))
+    if highlights:
+        filtered = [highlight.strip() for highlight in highlights if highlight and highlight.strip()]
+        if filtered:
+            sentences.append(_ensure_sentence("Highlights include " + "; ".join(filtered)))
+
+    return " ".join(_ensure_sentence(sentence) for sentence in sentences if sentence)
+
+
+def load_knowledge_graph_documents(
+    directory: Path,
+    *,
+    filename: str = "knowledge_graph.json",
+) -> List[Document]:
+    """Load knowledge graph triples and convert them into text documents."""
+
+    directory = directory.expanduser().resolve()
+    path = directory / filename
+    if not path.exists():
+        return []
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    nodes_data: List[dict] = data.get("nodes", [])  # type: ignore[assignment]
+    edges_data: List[dict] = data.get("edges", [])  # type: ignore[assignment]
+
+    nodes: Dict[str, dict] = {}
+    for node in nodes_data:
+        node_id = node.get("id")
+        if not node_id:
+            continue
+        nodes[str(node_id)] = node
+
+    grouped: Dict[str, List[str]] = defaultdict(list)
+    for edge in edges_data:
+        source_id = edge.get("source")
+        target_id = edge.get("target")
+        if not source_id or not target_id:
+            continue
+
+        subject = nodes.get(str(source_id), {}).get("label", str(source_id))
+        target = nodes.get(str(target_id), {}).get("label", str(target_id))
+        relation = str(edge.get("relation", "related_to"))
+        fact = _format_fact(
+            subject,
+            relation,
+            target,
+            start=edge.get("start"),
+            end=edge.get("end"),
+            location=edge.get("location"),
+            description=edge.get("description"),
+            highlights=edge.get("highlights"),
+        )
+        if fact:
+            grouped[subject].append(fact)
+
+    documents: List[Document] = []
+    if not grouped:
+        return documents
+
+    relative_source = str(path.relative_to(directory))
+    for index, (subject, facts) in enumerate(sorted(grouped.items()), start=1):
+        content = " ".join(facts).strip()
+        if not content:
+            continue
+        documents.append(
+            Document(
+                content=content,
+                metadata={
+                    "source": relative_source,
+                    "title": subject,
+                    "chunk": index,
+                },
+            )
+        )
+    return documents
+
+
+__all__ = ["load_knowledge_graph_documents"]

--- a/resume_chatbot/llm.py
+++ b/resume_chatbot/llm.py
@@ -1,0 +1,157 @@
+"""Language model abstractions for the resume chatbot."""
+
+from __future__ import annotations
+
+import os
+import re
+from abc import ABC, abstractmethod
+from typing import List, Optional, Sequence, Tuple
+
+
+ChatHistory = Sequence[Tuple[str, str]]
+
+
+class BaseLLM(ABC):
+    """Interface for language model backends."""
+
+    @abstractmethod
+    def generate(
+        self,
+        question: str,
+        context: str,
+        *,
+        system_prompt: Optional[str] = None,
+        chat_history: Optional[ChatHistory] = None,
+    ) -> str:
+        """Return an assistant response for ``question`` given ``context``."""
+
+
+class SimpleLLM(BaseLLM):
+    """Deterministic fallback LLM that summarises context snippets."""
+
+    def __init__(self, fallback_response: str | None = None, max_sentences: int = 3):
+        self.fallback_response = (
+            fallback_response
+            or "I could not find that information in the resume you provided."
+        )
+        self.max_sentences = max(1, max_sentences)
+
+    def _summarise(self, context: str) -> str:
+        sentences: list[str] = []
+        pattern = re.compile(r"[^.!?]+[.!?]")
+        for paragraph in context.split("\n\n"):
+            for match in pattern.findall(paragraph.strip()):
+                candidate = match.strip()
+                if candidate:
+                    sentences.append(candidate)
+        if not sentences:
+            fallback = context.replace("\n", " ").strip()
+            if fallback:
+                sentences.append(fallback)
+        if not sentences:
+            return ""
+        summary = " ".join(sentences[: self.max_sentences]).strip()
+        return summary
+
+    def generate(
+        self,
+        question: str,
+        context: str,
+        *,
+        system_prompt: Optional[str] = None,
+        chat_history: Optional[ChatHistory] = None,
+    ) -> str:
+        if not context.strip():
+            return self.fallback_response
+        summary = self._summarise(context)
+        if not summary:
+            return self.fallback_response
+        response = (
+            f"{summary}\n\nQuestion: {question.strip()}\n"
+            "This answer is based on the provided resume sections."
+        )
+        return response
+
+
+class OpenAIChatLLM(BaseLLM):
+    """Wrapper around the OpenAI Chat Completions API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        temperature: float = 0.1,
+        max_tokens: int | None = None,
+    ) -> None:
+        try:
+            from openai import OpenAI  # type: ignore
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ImportError(
+                "The 'openai' package is required for OpenAIChatLLM. Install resume-chatbot with the 'openai' extra."
+            ) from exc
+
+        self._client = OpenAI(api_key=api_key or os.getenv("OPENAI_API_KEY"))
+        if self._client.api_key is None:
+            raise ValueError("OPENAI_API_KEY is not set.")
+        self._model = model or os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+
+    @staticmethod
+    def _format_messages(
+        question: str,
+        context: str,
+        *,
+        system_prompt: Optional[str],
+        chat_history: Optional[ChatHistory],
+    ) -> List[dict[str, str]]:
+        messages: list[dict[str, str]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        if chat_history:
+            for user_turn, assistant_turn in chat_history:
+                messages.append({"role": "user", "content": user_turn})
+                messages.append({"role": "assistant", "content": assistant_turn})
+        user_prompt = (
+            "You are helping someone ask questions about a resume. "
+            "Use only the supplied resume context to answer succinctly. "
+            "If the context is insufficient, say you don't know.\n\n"
+            f"Resume context:\n{context}\n\nQuestion: {question}"
+        )
+        messages.append({"role": "user", "content": user_prompt})
+        return messages
+
+    def generate(
+        self,
+        question: str,
+        context: str,
+        *,
+        system_prompt: Optional[str] = None,
+        chat_history: Optional[ChatHistory] = None,
+    ) -> str:
+        messages = self._format_messages(
+            question,
+            context,
+            system_prompt=system_prompt,
+            chat_history=chat_history,
+        )
+        response = self._client.chat.completions.create(
+            model=self._model,
+            messages=messages,  # type: ignore[arg-type]
+            temperature=self._temperature,
+            max_tokens=self._max_tokens,
+        )
+        choice = response.choices[0]
+        return (choice.message.content or "").strip()
+
+
+def create_llm(backend: str) -> BaseLLM:
+    """Factory function that creates an LLM backend by name."""
+
+    backend = backend.lower().strip()
+    if backend == "simple":
+        return SimpleLLM()
+    if backend == "openai":
+        return OpenAIChatLLM()
+    raise ValueError("Unsupported LLM backend. Choose 'simple' or 'openai'.")

--- a/resume_chatbot/retriever.py
+++ b/resume_chatbot/retriever.py
@@ -1,0 +1,139 @@
+"""Lightweight TF-IDF retriever for resume documents."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from .data_loader import Document
+
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "to",
+    "with",
+}
+
+_TOKEN_PATTERN = re.compile(r"[a-zA-Z0-9']+")
+
+
+def _tokenise(text: str) -> list[str]:
+    tokens = [token.lower() for token in _TOKEN_PATTERN.findall(text)]
+    return [token for token in tokens if token not in _STOPWORDS]
+
+
+def _compute_idf(tokenised_documents: Sequence[Sequence[str]]) -> dict[str, float]:
+    df: Counter[str] = Counter()
+    for tokens in tokenised_documents:
+        for token in set(tokens):
+            df[token] += 1
+    num_documents = len(tokenised_documents)
+    return {
+        token: math.log((1 + num_documents) / (1 + count)) + 1
+        for token, count in df.items()
+    }
+
+
+@dataclass(frozen=True)
+class RetrievedDocument:
+    """A retrieved document and its similarity score."""
+
+    document: Document
+    score: float
+
+
+class ResumeRetriever:
+    """Perform simple TF-IDF retrieval over resume documents."""
+
+    def __init__(self, documents: Iterable[Document]):
+        self._documents: list[Document] = list(documents)
+        if not self._documents:
+            raise ValueError("ResumeRetriever requires at least one document")
+
+        self._tokenised_docs: list[list[str]] = [
+            _tokenise(document.content) for document in self._documents
+        ]
+        self._idf = _compute_idf(self._tokenised_docs)
+        self._document_vectors: list[tuple[dict[str, float], float]] = [
+            self._build_vector(tokens) for tokens in self._tokenised_docs
+        ]
+
+    def _build_vector(self, tokens: Sequence[str]) -> tuple[dict[str, float], float]:
+        tf = Counter(tokens)
+        vector: dict[str, float] = {}
+        norm = 0.0
+        length = float(len(tokens)) or 1.0
+        for token, count in tf.items():
+            if token not in self._idf:
+                continue
+            weight = (count / length) * self._idf[token]
+            if weight <= 0:
+                continue
+            vector[token] = weight
+            norm += weight * weight
+        return vector, math.sqrt(norm) if norm else 0.0
+
+    def _vectorise_query(self, query: str) -> tuple[dict[str, float], float]:
+        tokens = _tokenise(query)
+        tf = Counter(tokens)
+        vector: dict[str, float] = {}
+        norm = 0.0
+        length = float(len(tokens)) or 1.0
+        for token, count in tf.items():
+            idf = self._idf.get(token)
+            if idf is None:
+                continue
+            weight = (count / length) * idf
+            vector[token] = weight
+            norm += weight * weight
+        return vector, math.sqrt(norm) if norm else 0.0
+
+    @staticmethod
+    def _cosine_similarity(
+        vector_a: dict[str, float],
+        norm_a: float,
+        vector_b: dict[str, float],
+        norm_b: float,
+    ) -> float:
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        shared = set(vector_a) & set(vector_b)
+        dot_product = sum(vector_a[token] * vector_b[token] for token in shared)
+        return dot_product / (norm_a * norm_b)
+
+    def retrieve(self, query: str, top_k: int = 3) -> List[RetrievedDocument]:
+        """Return the ``top_k`` most relevant documents for ``query``."""
+
+        query_vector, query_norm = self._vectorise_query(query)
+        scored: list[RetrievedDocument] = []
+        for document, (doc_vector, doc_norm) in zip(
+            self._documents, self._document_vectors
+        ):
+            score = self._cosine_similarity(query_vector, query_norm, doc_vector, doc_norm)
+            if score <= 0:
+                continue
+            scored.append(RetrievedDocument(document=document, score=float(score)))
+        scored.sort(key=lambda item: item.score, reverse=True)
+        if top_k <= 0:
+            return scored
+        return scored[:top_k]

--- a/resume_chatbot/webapp.py
+++ b/resume_chatbot/webapp.py
@@ -1,0 +1,389 @@
+"""FastAPI-powered web interface for the resume chatbot."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
+from .chatbot import ResumeChatbot
+from .corpus import load_resume_corpus
+from .llm import create_llm
+from .retriever import ResumeRetriever
+
+
+class ChatRequest(BaseModel):
+    message: str = Field(..., description="User message to send to the chatbot.")
+
+
+class Source(BaseModel):
+    source: str
+    title: str | None = None
+    score: float
+
+
+class ChatResponse(BaseModel):
+    answer: str
+    sources: List[Source]
+
+
+def _build_chatbot(resume_directory: Path, llm_backend: str) -> ResumeChatbot:
+    documents = load_resume_corpus(resume_directory)
+    if not documents:
+        raise RuntimeError(
+            "No resume documents found. Add Markdown/text files to the resume directory."
+        )
+    retriever = ResumeRetriever(documents)
+    llm = create_llm(llm_backend)
+    return ResumeChatbot(retriever=retriever, llm=llm)
+
+
+def _render_index_html() -> str:
+    return """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>Resume Chatbot</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --panel: #1e293b;
+      --panel-border: #334155;
+      --text: #e2e8f0;
+      --accent: #38bdf8;
+      --accent-contrast: #0f172a;
+      --user-bg: #38bdf81f;
+      --assistant-bg: #22c55e20;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 32px 16px;
+    }
+
+    .app-shell {
+      width: min(960px, 100%);
+      background: rgba(15, 23, 42, 0.8);
+      backdrop-filter: blur(18px);
+      border: 1px solid var(--panel-border);
+      border-radius: 20px;
+      box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.6);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    header {
+      padding: 24px 32px;
+      border-bottom: 1px solid var(--panel-border);
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(1.8rem, 2vw + 1rem, 2.2rem);
+      letter-spacing: -0.02em;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    header h1 span {
+      background: linear-gradient(120deg, #38bdf8, #22d3ee);
+      -webkit-background-clip: text;
+      color: transparent;
+    }
+
+    header p {
+      margin: 0;
+      color: #94a3b8;
+      max-width: 680px;
+      line-height: 1.5;
+    }
+
+    .chat-window {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      padding: 24px 32px;
+      overflow-y: auto;
+      scroll-behavior: smooth;
+      background: linear-gradient(180deg, rgba(30, 41, 59, 0.45) 0%, rgba(15, 23, 42, 0.8) 100%);
+    }
+
+    .bubble {
+      padding: 16px 20px;
+      border-radius: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      line-height: 1.6;
+      backdrop-filter: blur(6px);
+      box-shadow: 0 10px 30px -15px rgba(148, 163, 184, 0.4);
+      animation: fadeIn 0.3s ease;
+      max-width: 85%;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .bubble.user {
+      align-self: flex-end;
+      background: var(--user-bg);
+      border-color: rgba(56, 189, 248, 0.35);
+    }
+
+    .bubble.assistant {
+      align-self: flex-start;
+      background: var(--assistant-bg);
+      border-color: rgba(34, 197, 94, 0.35);
+    }
+
+    .sources {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 0.9rem;
+      color: #cbd5f5;
+    }
+
+    .sources span {
+      opacity: 0.8;
+    }
+
+    form {
+      display: flex;
+      gap: 12px;
+      padding: 24px 32px;
+      border-top: 1px solid var(--panel-border);
+      background: rgba(15, 23, 42, 0.85);
+    }
+
+    textarea {
+      flex: 1;
+      resize: none;
+      background: rgba(15, 23, 42, 0.65);
+      border: 1px solid var(--panel-border);
+      border-radius: 16px;
+      padding: 16px;
+      color: var(--text);
+      font-size: 1rem;
+      line-height: 1.5;
+      min-height: 72px;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    textarea:focus {
+      outline: none;
+      border-color: rgba(56, 189, 248, 0.6);
+      box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+    }
+
+    button {
+      padding: 0 24px;
+      border-radius: 16px;
+      border: none;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      background: linear-gradient(120deg, #38bdf8, #22d3ee);
+      color: var(--accent-contrast);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px -12px rgba(56, 189, 248, 0.6);
+    }
+
+    button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(6px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @media (max-width: 600px) {
+      header, .chat-window, form {
+        padding: 20px;
+      }
+
+      .bubble {
+        max-width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class=\"app-shell\">
+    <header>
+      <h1>Resume <span>Chatbot</span></h1>
+      <p>Ask questions about the resume and receive grounded answers powered by retrieval-augmented generation.</p>
+    </header>
+    <main class=\"chat-window\" id=\"chat-window\">
+      <div class=\"bubble assistant\">
+        <strong>Assistant</strong>
+        <span>Hi! I'm ready to answer questions about this resume. What would you like to know?</span>
+      </div>
+    </main>
+    <form id=\"chat-form\">
+      <textarea id=\"chat-input\" placeholder=\"Ask about experience, skills, education...\" required></textarea>
+      <button type=\"submit\">Send</button>
+    </form>
+  </div>
+
+  <script>
+    const form = document.getElementById('chat-form');
+    const input = document.getElementById('chat-input');
+    const chatWindow = document.getElementById('chat-window');
+
+    function appendBubble(role, content, sources = []) {
+      const bubble = document.createElement('div');
+      bubble.className = `bubble ${role}`;
+
+      const name = document.createElement('strong');
+      name.textContent = role === 'user' ? 'You' : 'Assistant';
+      bubble.appendChild(name);
+
+      const message = document.createElement('span');
+      message.innerText = content;
+      bubble.appendChild(message);
+
+      if (sources.length > 0) {
+        const list = document.createElement('div');
+        list.className = 'sources';
+        const heading = document.createElement('span');
+        heading.textContent = 'Sources';
+        list.appendChild(heading);
+
+        sources.forEach((source) => {
+          const item = document.createElement('span');
+          const title = source.title ? ` :: ${source.title}` : '';
+          item.textContent = `${source.source}${title} (score: ${source.score.toFixed(3)})`;
+          list.appendChild(item);
+        });
+        bubble.appendChild(list);
+      }
+
+      chatWindow.appendChild(bubble);
+      chatWindow.scrollTop = chatWindow.scrollHeight;
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const message = input.value.trim();
+      if (!message) {
+        return;
+      }
+
+      appendBubble('user', message);
+      input.value = '';
+
+      const button = form.querySelector('button');
+      button.disabled = true;
+
+      try {
+        const response = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message })
+        });
+
+        if (!response.ok) {
+          const error = await response.json();
+          throw new Error(error.detail || 'Request failed');
+        }
+
+        const data = await response.json();
+        appendBubble('assistant', data.answer, data.sources || []);
+      } catch (error) {
+        appendBubble('assistant', error.message || 'Something went wrong.');
+      } finally {
+        button.disabled = false;
+        input.focus();
+      }
+    });
+  </script>
+</body>
+</html>"""
+
+
+def create_app(
+    *,
+    resume_directory: Path = Path("data/resume"),
+    llm_backend: str = "simple",
+    top_k: int = 3,
+) -> FastAPI:
+    """Create a FastAPI app backed by the resume chatbot."""
+
+    chatbot = _build_chatbot(resume_directory, llm_backend)
+    app = FastAPI(title="Resume Chatbot", version="1.0.0")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.state.chatbot = chatbot
+    app.state.top_k = top_k
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> HTMLResponse:
+        return HTMLResponse(content=_render_index_html())
+
+    @app.post("/api/chat", response_model=ChatResponse)
+    async def chat(request: ChatRequest) -> ChatResponse:
+        message = request.message.strip()
+        if not message:
+            raise HTTPException(status_code=400, detail="Message cannot be empty.")
+
+        result = app.state.chatbot.ask(message, top_k=app.state.top_k)
+        sources: List[Dict[str, Any]] = []
+        for item in result.documents:
+            metadata = item.document.metadata
+            sources.append(
+                {
+                    "source": metadata.get("source", "resume"),
+                    "title": metadata.get("title"),
+                    "score": item.score,
+                }
+            )
+
+        return ChatResponse(answer=result.answer, sources=[Source(**source) for source in sources])
+
+    return app
+
+
+app = create_app()
+
+
+__all__ = ["create_app", "app"]

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,0 +1,62 @@
+from resume_chatbot.chatbot import DEFAULT_SYSTEM_PROMPT, ChatResult, ResumeChatbot
+from resume_chatbot.data_loader import Document
+from resume_chatbot.llm import SimpleLLM
+from resume_chatbot.retriever import ResumeRetriever
+
+
+def build_chatbot(documents: list[Document]) -> ResumeChatbot:
+    retriever = ResumeRetriever(documents)
+    llm = SimpleLLM()
+    return ResumeChatbot(retriever=retriever, llm=llm, system_prompt=DEFAULT_SYSTEM_PROMPT)
+
+
+def test_chatbot_returns_answer_from_context():
+    documents = [
+        Document(
+            content="Alex has over 7 years of experience working with Python and large language models.",
+            metadata={"source": "resume.md", "title": "Summary"},
+        )
+    ]
+    chatbot = build_chatbot(documents)
+
+    response = chatbot.ask("How much Python experience does Alex have?", top_k=1)
+
+    assert isinstance(response, ChatResult)
+    assert "7 years" in response.answer
+    assert response.documents[0].document.metadata["title"] == "Summary"
+
+
+def test_chatbot_uses_fallback_when_no_context():
+    documents = [
+        Document(
+            content="Alex is based in Seattle.",
+            metadata={"source": "resume.md", "title": "Contact"},
+        )
+    ]
+    chatbot = build_chatbot(documents)
+
+    response = chatbot.ask("What is Alex's favourite programming language?", top_k=1)
+
+    assert "could not" in response.answer.lower()
+    assert response.documents == []
+
+
+def test_chat_history_is_capped():
+    documents = [
+        Document(
+            content="Alex mentors engineers.",
+            metadata={"source": "resume.md", "title": "Community"},
+        )
+    ]
+    chatbot = ResumeChatbot(
+        retriever=ResumeRetriever(documents),
+        llm=SimpleLLM(),
+        system_prompt=DEFAULT_SYSTEM_PROMPT,
+        history_limit=2,
+    )
+
+    chatbot.ask("Tell me about Alex's mentoring.")
+    chatbot.ask("Does Alex enjoy teaching?")
+    chatbot.ask("What leadership has Alex demonstrated?")
+
+    assert len(chatbot.history) == 2

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from resume_chatbot.corpus import load_resume_corpus
+
+
+def test_load_resume_corpus_combines_sources() -> None:
+    documents = load_resume_corpus(Path("data/resume"))
+    assert documents, "Expected resume documents to be loaded."
+
+    sources = {document.metadata.get("source") for document in documents}
+    assert "resume_example.md" in sources
+    assert "knowledge_graph.json" in sources

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from resume_chatbot.data_loader import Document, _split_markdown_sections, load_resume_documents
+
+
+def test_split_markdown_sections_creates_chunks(tmp_path: Path):
+    content = """# Title\nIntro paragraph.\n\n## Experience\nDid things.\n\n## Skills\nPython\n"""
+    sections = list(_split_markdown_sections(content))
+
+    assert sections[0][0] == "Title"
+    assert "Intro" in sections[0][1]
+    assert sections[1][0] == "Experience"
+    assert "Did things" in sections[1][1]
+
+
+def test_load_resume_documents(tmp_path: Path):
+    resume_dir = tmp_path / "resume"
+    resume_dir.mkdir()
+    file_path = resume_dir / "resume.md"
+    file_path.write_text("""# Summary\nLine one.\n\n## Skills\nPython\n""", encoding="utf-8")
+
+    documents = load_resume_documents(resume_dir)
+
+    assert len(documents) == 2
+    assert documents[0].metadata["source"] == "resume.md"
+    assert documents[0].metadata["chunk"] == 1
+    assert documents[1].metadata["title"] == "Skills"

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from resume_chatbot.knowledge_graph import load_knowledge_graph_documents
+
+
+def test_load_knowledge_graph_documents(tmp_path: Path) -> None:
+    graph = {
+        "title": "Test Graph",
+        "nodes": [
+            {"id": "person", "label": "Alex Example"},
+            {"id": "company", "label": "Example Corp"},
+        ],
+        "edges": [
+            {
+                "source": "person",
+                "target": "company",
+                "relation": "worked_at",
+                "start": "2023",
+                "end": "2024",
+                "location": "Remote",
+                "description": "Senior data scientist building production pipelines.",
+                "highlights": ["Implemented retrievers", "Managed 5-person team"],
+            }
+        ],
+    }
+    (tmp_path / "knowledge_graph.json").write_text(json.dumps(graph), encoding="utf-8")
+
+    documents = load_knowledge_graph_documents(tmp_path)
+
+    assert len(documents) == 1
+    document = documents[0]
+    assert document.metadata["source"] == "knowledge_graph.json"
+    assert "Alex Example" in document.metadata["title"]
+    content = document.content.lower()
+    assert "worked at" in content
+    assert "highlights include" in content
+
+
+def test_load_knowledge_graph_documents_missing_file(tmp_path: Path) -> None:
+    documents = load_knowledge_graph_documents(tmp_path)
+    assert documents == []

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -1,0 +1,13 @@
+import pytest
+
+from resume_chatbot.llm import SimpleLLM, create_llm
+
+
+def test_create_llm_simple_backend() -> None:
+    llm = create_llm("simple")
+    assert isinstance(llm, SimpleLLM)
+
+
+def test_create_llm_invalid_backend() -> None:
+    with pytest.raises(ValueError):
+        create_llm("unsupported")

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from resume_chatbot.data_loader import Document
+from resume_chatbot.retriever import ResumeRetriever
+
+
+def test_retriever_returns_high_score_for_matching_document():
+    docs = [
+        Document(
+            content="Alex is a machine learning engineer specialising in retrieval augmented generation.",
+            metadata={"source": "resume.md", "title": "Summary"},
+        ),
+        Document(
+            content="Alex volunteers at the local AI meetup.",
+            metadata={"source": "resume.md", "title": "Volunteering"},
+        ),
+    ]
+    retriever = ResumeRetriever(docs)
+
+    results = retriever.retrieve("What kind of engineer is Alex?", top_k=1)
+
+    assert results
+    assert "machine learning" in results[0].document.content
+
+
+def test_retriever_handles_zero_matches():
+    docs = [
+        Document(
+            content="The candidate enjoys mentoring.",
+            metadata={"source": "resume.md", "title": "Community"},
+        )
+    ]
+    retriever = ResumeRetriever(docs)
+
+    results = retriever.retrieve("What certifications does Alex hold?", top_k=3)
+
+    assert results == []
+
+
+def test_retriever_requires_documents():
+    with pytest.raises(ValueError):
+        ResumeRetriever([])

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from resume_chatbot.webapp import create_app
+
+
+def test_webapp_index_serves_html() -> None:
+    app = create_app(resume_directory=Path("data/resume"))
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "<title>Resume Chatbot</title>" in response.text
+
+
+def test_webapp_chat_endpoint_returns_sources() -> None:
+    app = create_app(resume_directory=Path("data/resume"), top_k=2)
+    client = TestClient(app)
+    response = client.post("/api/chat", json={"message": "What programming languages are listed?"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["answer"]
+    assert isinstance(payload["sources"], list)
+    assert payload["sources"], "Expected at least one source to be returned."


### PR DESCRIPTION
## Summary
- add a FastAPI-powered web interface with a polished chat UI and JSON API for the resume chatbot
- extract shared helpers for loading the resume corpus and instantiating LLM backends to reuse between the CLI and web app
- document the new web workflow, add required dependencies, and cover the new utilities and web endpoints with automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3900208e08326a58cfe2990f79bb6